### PR TITLE
Fix temporary directory naming for uniqueness.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embed-prisma",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Exposes Prisma's compiler API for NodeJS applications",
   "scripts": {
     "build": "rimraf lib && tsc && rollup -c",

--- a/src/EmbedPrisma.ts
+++ b/src/EmbedPrisma.ts
@@ -65,7 +65,7 @@ export class EmbedPrisma {
   ): Promise<IEmbedPrismaResult> {
     // PREPARE DIRECTORIES
     const directory: string = await fs.promises.mkdtemp(
-      `${os.tmpdir()}/embed-prisma-`,
+      `${os.tmpdir()}/samchon/embed-prisma-${Math.random().toString(16).substring(2)}`,
     );
     await fs.promises.mkdir(`${directory}/schemas`, {
       recursive: true,

--- a/src/EmbedPrisma.ts
+++ b/src/EmbedPrisma.ts
@@ -65,7 +65,7 @@ export class EmbedPrisma {
   ): Promise<IEmbedPrismaResult> {
     // PREPARE DIRECTORIES
     const directory: string = await fs.promises.mkdtemp(
-      `${os.tmpdir()}/samchon/embed-prisma-${Math.random().toString(16).substring(2)}`,
+      `${os.tmpdir()}/embed-prisma-${Math.random().toString(16).substring(2)}`,
     );
     await fs.promises.mkdir(`${directory}/schemas`, {
       recursive: true,

--- a/src/EmbedPrisma.ts
+++ b/src/EmbedPrisma.ts
@@ -65,7 +65,7 @@ export class EmbedPrisma {
   ): Promise<IEmbedPrismaResult> {
     // PREPARE DIRECTORIES
     const directory: string = await fs.promises.mkdtemp(
-      `${os.tmpdir()}/embed-prisma-${Math.random().toString(16).substring(2)}`,
+      `${os.tmpdir()}/embed-prisma-${crypto.randomUUID()}`,
     );
     await fs.promises.mkdir(`${directory}/schemas`, {
       recursive: true,

--- a/src/EmbedPrisma.ts
+++ b/src/EmbedPrisma.ts
@@ -8,6 +8,7 @@ import {
   getDMMF,
   mergeSchemas,
 } from "@prisma/internals";
+import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";


### PR DESCRIPTION
This pull request includes a version bump for the `embed-prisma` package and a change to the temporary directory naming convention in the `EmbedPrisma` class to improve uniqueness and avoid potential conflicts.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.1.0` to `1.1.1`.

### Code Improvement:
* [`src/EmbedPrisma.ts`](diffhunk://#diff-40f81b7e3730c65e0d5dca32ad18f5a0dab9d8dd18c81439e09263b3e52443d8L68-R68): Modified the temporary directory naming logic in the `EmbedPrisma` class to include a random hexadecimal string, improving uniqueness and reducing the likelihood of naming collisions.