### PR TITLE
Bump up Prisma v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 25
+    versioning-strategy: increase
+    allow:
+      - dependency-name: "@prisma/*"
+      - dependency-name: "prisma"
+      - dependency-type: "prisma-markdown"
+    groups:
+      Prisma:
+        patterns:
+          - "@prisma/*"
+          - "prisma"
+          - "prisma-markdown"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,19 @@
 # author: elliot-huffman
 name: release
+permissions:
+  id-token: write
+  contents: write
 on:
   release:
     types: [created]
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v2
         with:
@@ -25,5 +25,4 @@ jobs:
       - name: Publish to npm
         run: pnpm --filter=./ -r publish --no-git-checks --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}
           NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embed-prisma",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Exposes Prisma's compiler API for NodeJS applications",
   "scripts": {
     "build": "rimraf lib && tsc && rollup -c",
@@ -32,11 +32,11 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@prisma/client": "^6.16.2",
-    "@prisma/client-generator-js": "^6.16.2",
-    "@prisma/generator-helper": "^6.16.2",
-    "@prisma/internals": "^6.16.2",
-    "prisma-markdown": "^3.0.1"
+    "@prisma/client": "^7.0.0",
+    "@prisma/client-generator-js": "^7.0.0",
+    "@prisma/generator-helper": "^7.0.0",
+    "@prisma/internals": "^7.0.0",
+    "prisma-markdown": "^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       '@prisma/client':
-        specifier: ^6.16.2
-        version: 6.16.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
+        specifier: ^7.0.0
+        version: 7.0.0(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
       '@prisma/client-generator-js':
-        specifier: ^6.16.2
-        version: 6.16.2(typescript@5.8.3)
+        specifier: ^7.0.0
+        version: 7.0.0(typescript@5.8.3)
       '@prisma/generator-helper':
-        specifier: ^6.16.2
-        version: 6.16.2
+        specifier: ^7.0.0
+        version: 7.0.0
       '@prisma/internals':
-        specifier: ^6.16.2
-        version: 6.16.2(typescript@5.8.3)
+        specifier: ^7.0.0
+        version: 7.0.0(typescript@5.8.3)
       prisma-markdown:
-        specifier: ^3.0.1
-        version: 3.0.1(@prisma/client@6.16.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3))(prisma@6.8.2(typescript@5.8.3))
+        specifier: ^4.0.0
+        version: 4.0.0(@prisma/client@7.0.0(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3))(prisma@6.8.2(typescript@5.8.3))
     devDependencies:
       '@rollup/plugin-terser':
         specifier: ^0.4.4
@@ -61,8 +61,8 @@ importers:
         specifier: workspace:^
         version: link:..
       typia:
-        specifier: ^9.3.0
-        version: 9.3.0(@samchon/openapi@4.3.0)(typescript@5.8.3)
+        specifier: ^10.1.0
+        version: 10.1.0(typescript@5.8.3)
     devDependencies:
       ts-node:
         specifier: ^10.9.2
@@ -162,94 +162,97 @@ packages:
   '@paralleldrive/cuid2@2.2.2':
     resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
 
-  '@prisma/client-common@6.16.2':
-    resolution: {integrity: sha512-j4QlXSJfEQ6grK75k6TJAxuyMcc76v+RREgDDxyin1FBL1Ik6tLPH5ruhS0C/deuYiKoZ8Rd2LEGMtQAbh4Wag==}
+  '@prisma/client-common@7.0.0':
+    resolution: {integrity: sha512-dZTkSh+aDcBJY//6iIw0VqoBp4oi5NFVhrionUbLG12C5uPP3kipGlPYRAewlYK9h/dDHDMXPcMzh4n3OZiy4A==}
 
-  '@prisma/client-engine-runtime@6.16.2':
-    resolution: {integrity: sha512-gC0Vi86+/z8X0Hju8JxUNnwydD5o8FeEj1mb1TzDGCp3cvecchJZ2awrge3Hum0imT0BrCfmN5Z3ZZqIOCAYnA==}
+  '@prisma/client-engine-runtime@7.0.0':
+    resolution: {integrity: sha512-RFB51k/2vHrgvyQ5MLm8WcQTyvsx/4rjGe2AHeYeJimnTjBDrcGPB4yz3z4j0cBcgW5NB3CF0xMj6jAbA5z7Ig==}
 
-  '@prisma/client-generator-js@6.16.2':
-    resolution: {integrity: sha512-7oRZKtF634aJtEemHPdHboOqaf0FJYtWUJz7Az2WpfiLDMuDTC/jjIkrqwOFEK/5C2C9fNoQeRzX2EZFxqngGg==}
+  '@prisma/client-generator-js@7.0.0':
+    resolution: {integrity: sha512-/IPjWAhdix14wccoxP6lvJ4X+r3N8PFIqkKOBJW7r7LRmisMWZBjIgkA058Yl2QZ4DiXJyfek4Z+rehv9fmFvQ==}
 
-  '@prisma/client@6.16.2':
-    resolution: {integrity: sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==}
-    engines: {node: '>=18.18'}
+  '@prisma/client-runtime-utils@7.0.0':
+    resolution: {integrity: sha512-PAiFgMBPrLSaakBwUpML5NevipuKSL3rtNr8pZ8CZ3OBXo0BFcdeGcBIKw/CxJP6H4GNa4+l5bzJPrk8Iq6tDw==}
+
+  '@prisma/client@7.0.0':
+    resolution: {integrity: sha512-FM1NtJezl0zH3CybLxcbJwShJt7xFGSRg+1tGhy3sCB8goUDnxnBR+RC/P35EAW8gjkzx7kgz7bvb0MerY2VSw==}
+    engines: {node: ^20.19 || ^22.12 || ^24.0}
     peerDependencies:
       prisma: '*'
-      typescript: '>=5.1.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       prisma:
         optional: true
       typescript:
         optional: true
 
-  '@prisma/config@6.16.2':
-    resolution: {integrity: sha512-mKXSUrcqXj0LXWPmJsK2s3p9PN+aoAbyMx7m5E1v1FufofR1ZpPoIArjjzOIm+bJRLLvYftoNYLx1tbHgF9/yg==}
-
   '@prisma/config@6.8.2':
     resolution: {integrity: sha512-ZJY1fF4qRBPdLQ/60wxNtX+eu89c3AkYEcP7L3jkp0IPXCNphCYxikTg55kPJLDOG6P0X+QG5tCv6CmsBRZWFQ==}
 
-  '@prisma/debug@6.16.2':
-    resolution: {integrity: sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==}
+  '@prisma/config@7.0.0':
+    resolution: {integrity: sha512-TDASB57hyGUwHB0IPCSkoJcXFrJOKA1+R/1o4np4PbS+E0F5MiY5aAyUttO0mSuNQaX7t8VH/GkDemffF1mQzg==}
 
   '@prisma/debug@6.8.2':
     resolution: {integrity: sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==}
 
-  '@prisma/dmmf@6.16.2':
-    resolution: {integrity: sha512-o9ztgdbj2KZXl6DL+oP56TTC0poTLPns9/MeU761b49E1IQ/fd0jwdov1bidlNOiwio8Nsou23xNrYE/db10aA==}
+  '@prisma/debug@7.0.0':
+    resolution: {integrity: sha512-SdS3qzfMASHtWimywtkiRcJtrHzacbmMVhElko3DYUZSB0TTLqRYWpddRBJdeGgSLmy1FD55p7uGzIJ+MtfhMg==}
 
-  '@prisma/driver-adapter-utils@6.16.2':
-    resolution: {integrity: sha512-DMgfafnG0zPd+QoAQOC0Trn1xlb0fVAfQi2MpkpzSf641KiVkVPkJRXDSbcTbxGxO2HRdd0vI9U6LlesWad4XA==}
+  '@prisma/dmmf@7.0.0':
+    resolution: {integrity: sha512-Te1mE1K5M/qO4iYMC3LYrrAbAGlxcah+Bx1YFRLlewu6Ah5tgp9ZhDQ3W/nRAWBeWyNrnhnkTWBNkcXJYtRy+g==}
 
-  '@prisma/engines-version@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43':
-    resolution: {integrity: sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==}
+  '@prisma/driver-adapter-utils@7.0.0':
+    resolution: {integrity: sha512-ZEvzFaIapnfNKFPgZu/Zy4g6jfO5C0ZmMp+IjO9hNKNDwVKrDlBKw7F3Y9oRK0U0kfb9lKWP4Dz7DgtKs4TTbA==}
+
+  '@prisma/engines-version@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513':
+    resolution: {integrity: sha512-7bzyN8Gp9GbDFbTDzVUH9nFcgRWvsWmjrGgBJvIC/zEoAuv/lx62gZXgAKfjn/HoPkxz/dS+TtsnduFx8WA+cw==}
 
   '@prisma/engines-version@6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e':
     resolution: {integrity: sha512-Rkik9lMyHpFNGaLpPF3H5q5TQTkm/aE7DsGM5m92FZTvWQsvmi6Va8On3pWvqLHOt5aPUvFb/FeZTmphI4CPiQ==}
 
-  '@prisma/engines@6.16.2':
-    resolution: {integrity: sha512-7yf3AjfPUgsg/l7JSu1iEhsmZZ/YE00yURPjTikqm2z4btM0bCl2coFtTGfeSOWbQMmq45Jab+53yGUIAT1sjA==}
-
   '@prisma/engines@6.8.2':
     resolution: {integrity: sha512-XqAJ//LXjqYRQ1RRabs79KOY4+v6gZOGzbcwDQl0D6n9WBKjV7qdrbd042CwSK0v0lM9MSHsbcFnU2Yn7z8Zlw==}
 
-  '@prisma/fetch-engine@6.16.2':
-    resolution: {integrity: sha512-wPnZ8DMRqpgzye758ZvfAMiNJRuYpz+rhgEBZi60ZqDIgOU2694oJxiuu3GKFeYeR/hXxso4/2oBC243t/whxQ==}
+  '@prisma/engines@7.0.0':
+    resolution: {integrity: sha512-ojCL3OFLMCz33UbU9XwH32jwaeM+dWb8cysTuY8eK6ZlMKXJdy6ogrdG3MGB3meKLGdQBmOpUUGJ7eLIaxbrcg==}
 
   '@prisma/fetch-engine@6.8.2':
     resolution: {integrity: sha512-lCvikWOgaLOfqXGacEKSNeenvj0n3qR5QvZUOmPE2e1Eh8cMYSobxonCg9rqM6FSdTfbpqp9xwhSAOYfNqSW0g==}
 
-  '@prisma/generator-helper@6.16.2':
-    resolution: {integrity: sha512-8tVnWM8ETJNrvI5CT9eKCW23+aPLNkidC+g9NJn7ghXm60Q7GGlLX5tmvn5dE8tXvs/FSX3MN7KNmNJpOr89Hw==}
+  '@prisma/fetch-engine@7.0.0':
+    resolution: {integrity: sha512-qcyWTeWDjVDaDQSrVIymZU1xCYlvmwCzjA395lIuFjUESOH3YQCb8i/hpd4vopfq3fUR4v6+MjjtIGvnmErQgw==}
 
-  '@prisma/generator@6.16.2':
-    resolution: {integrity: sha512-7bwRmtMIgfe1rUynh1p9VlmYvEiidbRO6aBphPBS6YGEGSvNe8+QExbRpsqFlFBvIX76BhZCxuEj7ZwALMYRKQ==}
+  '@prisma/generator-helper@7.0.0':
+    resolution: {integrity: sha512-zVdOzhEBXBcJxUubW3SQ2y9Y+uHCSv44ZiX9yXVVVn9cev13sNOPbP24yglCUx2ehHlLjZ324KLDvqxVAcx4hQ==}
 
-  '@prisma/get-platform@6.16.2':
-    resolution: {integrity: sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==}
+  '@prisma/generator@7.0.0':
+    resolution: {integrity: sha512-nOcN8uFVVkw9QroZX2cZY7w+epb/5VsTbBpz7m9Lp1zhW/usxH7p8ZfP3LhFUSSelb7mslvBRNRRumQp5IAmiw==}
 
   '@prisma/get-platform@6.8.2':
     resolution: {integrity: sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==}
 
-  '@prisma/internals@6.16.2':
-    resolution: {integrity: sha512-gwmWl7H8iTbi+58RXua5Lsus5LDbIZGO2wQ4RoSX9YtEbKWHwRP8TUzTVLwRNeJ2DHwfnzhTLrUnybwotqiACg==}
+  '@prisma/get-platform@7.0.0':
+    resolution: {integrity: sha512-zyhzrAa+y/GfyCzTnuk0D9lfkvDzo7IbsNyuhTqhPu/AN0txm0x26HAR4tJLismla/fHf5fBzYwSivYSzkpakg==}
+
+  '@prisma/internals@7.0.0':
+    resolution: {integrity: sha512-ka2G6XQHPCrQDWG/LsxbSLJ0o233Y1q1KXJOzzYVBsfKasigg1DpN+/ofGJVEPZREXpCkOeYE89mirxdBHT2AA==}
     peerDependencies:
-      typescript: '>=5.1.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@prisma/prisma-schema-wasm@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43':
-    resolution: {integrity: sha512-DvYi0zKqzPd49Z5japS3FawyMylscaoUmlXNhnRAXb8HZryG4Q7TM1FLX8OIAfCgLmoWS1c/Zf4UZznBXkvWSg==}
+  '@prisma/prisma-schema-wasm@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513':
+    resolution: {integrity: sha512-+eoPe1nCLjRLfdvNBOUIraozozRe6IgfYNS3u/j+GcQZgg82kTYwiMzYcgJb0D6giqddv60W8c3F5OxeFV6Kiw==}
 
-  '@prisma/schema-engine-wasm@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43':
-    resolution: {integrity: sha512-HDgFE0um5OHkk2pkQbAgARR284i2VpoM+7GYRAT0zxoTagsdaZ6yquJF2LEZuAKfibib0Ct7JZxRCB8eN/Ru6g==}
+  '@prisma/schema-engine-wasm@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513':
+    resolution: {integrity: sha512-2BhRjCnWXPHsYMxslnKrqN+3EarnECsqlx+j3K5eWcnArlW0ZpOC+ay9ahyuIm7umU+eOceTnDrpv8WPVdo0oQ==}
 
-  '@prisma/schema-files-loader@6.16.2':
-    resolution: {integrity: sha512-TN77DUFgOxT/WL6wuxVhn7qVDvwVRl0TEzhFfRh5vKQsuZ5itLzA7Ki4TgOs4Pk18wwZnti6ZKdzR3Y7cu2KsA==}
+  '@prisma/schema-files-loader@7.0.0':
+    resolution: {integrity: sha512-S/WKnkQ4m/h3Otl6yV/yW14UT1Ymseth01HVcuWfwQF4skqsJ+xd2WMPWouJcvjjgh+f1iEdKJoKjn3LXPE0hg==}
 
-  '@prisma/ts-builders@6.16.2':
-    resolution: {integrity: sha512-iYnlfPdBLPt8tu5kPreIBBWwqKIDh81qYNi3Ea4xNY0NLXpiM4c+EcEP1vxUV+Us0wc3oCH2fSKdKAiFxG/tRg==}
+  '@prisma/ts-builders@7.0.0':
+    resolution: {integrity: sha512-G39w/nTYGxIEmuUhx8Z1otUV6XiwnYUBcgA/I13gtvJoQU6wt9Aqbq2LeAw3XuQUw3O3hSXdLHOormnWptjRSQ==}
 
   '@rollup/plugin-terser@0.4.4':
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
@@ -382,8 +385,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@samchon/openapi@4.3.0':
-    resolution: {integrity: sha512-PdagymZCUCPmhtfriO+6xYRulds2hgo1ec0LduPFEAOWkZ4viM15iRuEa5wkm9DkDRF/oaMiC+dOgXefmOFZAA==}
+  '@samchon/openapi@5.1.0':
+    resolution: {integrity: sha512-PudEhIB/YO+NJPv712+6U7H5qVGJ314QfOnabRxLWoR/A3Hw/wHuHq1Yeb1sdi1Xlx3dUWvGTKXuzE2qEfWR0w==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -497,10 +500,6 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  ci-info@4.2.0:
-    resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
-    engines: {node: '>=8'}
-
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
@@ -564,9 +563,6 @@ packages:
       supports-color:
         optional: true
 
-  decimal.js@10.5.0:
-    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
-
   deepmerge-ts@7.1.5:
     resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
     engines: {node: '>=16.0.0'}
@@ -595,8 +591,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  effect@3.16.12:
-    resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
+  effect@3.18.4:
+    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -879,12 +875,12 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prisma-markdown@3.0.1:
-    resolution: {integrity: sha512-2ZgEfz1wFfORYWY0Hg/xiHnhT5tY20ql5TNU3l79U9A3is2X6RLjU7KlBcP4+rg5Bl/i9fHEQqkn3qY0m0Fh5w==}
+  prisma-markdown@4.0.0:
+    resolution: {integrity: sha512-QtyRRv/m0sc1a9xTrsFe+wDX1oqU2Le/v3bjklujG4Zc4Dpe5SbVlkhV2E6PevKaMxjvxGvYsYM4u8Ppx9qoeQ==}
     hasBin: true
     peerDependencies:
-      '@prisma/client': '>= 6.0.0'
-      prisma: '>= 6.0.0'
+      '@prisma/client': '>= 7.0.0'
+      prisma: '>= 7.0.0'
 
   prisma@6.8.2:
     resolution: {integrity: sha512-JNricTXQxzDtRS7lCGGOB4g5DJ91eg3nozdubXze3LpcMl1oWwcFddrj++Up3jnRE6X/3gB/xz3V+ecBk/eEGA==}
@@ -1075,12 +1071,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@9.3.0:
-    resolution: {integrity: sha512-srQSYteGIrMiM36y/8MfqrCYA2RWyk4Bb7Xrlk3Ywfpc7AmmzcxwZkPuC4xOkI1IwRfjkhM7k4wviRb6WtW46g==}
+  typia@10.1.0:
+    resolution: {integrity: sha512-lKeDr+hv9hJgZbQhXtGZ2CUtGNaG6zN9Bz+t9fPIaaFcAbYbZstoo7887eqkCfg+C19QfNGRyGtLwiALvovczA==}
     hasBin: true
     peerDependencies:
-      '@samchon/openapi': '>=4.3.0 <5.0.0'
-      typescript: '>=4.8.0 <5.9.0'
+      typescript: '>=4.8.0 <5.10.0'
 
   ulid@3.0.0:
     resolution: {integrity: sha512-yvZYdXInnJve6LdlPIuYmURdS2NP41ZoF4QW7SXwbUKYt53+0eDAySO+rGSvM2O/ciuB/G+8N7GQrZ1mCJpuqw==}
@@ -1233,42 +1228,41 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@prisma/client-common@6.16.2(typescript@5.8.3)':
+  '@prisma/client-common@7.0.0(typescript@5.8.3)':
     dependencies:
-      '@prisma/client-engine-runtime': 6.16.2
-      '@prisma/dmmf': 6.16.2
-      '@prisma/driver-adapter-utils': 6.16.2
-      '@prisma/generator': 6.16.2
-      '@prisma/internals': 6.16.2(typescript@5.8.3)
+      '@prisma/client-engine-runtime': 7.0.0
+      '@prisma/dmmf': 7.0.0
+      '@prisma/driver-adapter-utils': 7.0.0
+      '@prisma/generator': 7.0.0
+      '@prisma/internals': 7.0.0(typescript@5.8.3)
     transitivePeerDependencies:
       - magicast
       - typescript
 
-  '@prisma/client-engine-runtime@6.16.2':
+  '@prisma/client-engine-runtime@7.0.0':
     dependencies:
       '@bugsnag/cuid': 3.2.1
       '@opentelemetry/api': 1.9.0
       '@paralleldrive/cuid2': 2.2.2
-      '@prisma/debug': 6.16.2
-      '@prisma/driver-adapter-utils': 6.16.2
-      decimal.js: 10.5.0
+      '@prisma/client-runtime-utils': 7.0.0
+      '@prisma/debug': 7.0.0
+      '@prisma/driver-adapter-utils': 7.0.0
       nanoid: 5.1.5
       ulid: 3.0.0
       uuid: 11.1.0
 
-  '@prisma/client-generator-js@6.16.2(typescript@5.8.3)':
+  '@prisma/client-generator-js@7.0.0(typescript@5.8.3)':
     dependencies:
       '@antfu/ni': 0.21.12
-      '@prisma/client-common': 6.16.2(typescript@5.8.3)
-      '@prisma/debug': 6.16.2
-      '@prisma/dmmf': 6.16.2
-      '@prisma/engines-version': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
-      '@prisma/fetch-engine': 6.16.2
-      '@prisma/generator': 6.16.2
-      '@prisma/get-platform': 6.16.2
-      '@prisma/internals': 6.16.2(typescript@5.8.3)
-      '@prisma/ts-builders': 6.16.2(typescript@5.8.3)
-      ci-info: 4.2.0
+      '@prisma/client-common': 7.0.0(typescript@5.8.3)
+      '@prisma/debug': 7.0.0
+      '@prisma/dmmf': 7.0.0
+      '@prisma/engines-version': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
+      '@prisma/fetch-engine': 7.0.0
+      '@prisma/generator': 7.0.0
+      '@prisma/get-platform': 7.0.0
+      '@prisma/internals': 7.0.0(typescript@5.8.3)
+      '@prisma/ts-builders': 7.0.0(typescript@5.8.3)
       env-paths: 2.2.1
       indent-string: 4.0.0
       klona: 2.0.6
@@ -1279,44 +1273,41 @@ snapshots:
       - magicast
       - typescript
 
-  '@prisma/client@6.16.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)':
+  '@prisma/client-runtime-utils@7.0.0': {}
+
+  '@prisma/client@7.0.0(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)':
+    dependencies:
+      '@prisma/client-runtime-utils': 7.0.0
     optionalDependencies:
       prisma: 6.8.2(typescript@5.8.3)
       typescript: 5.8.3
-
-  '@prisma/config@6.16.2':
-    dependencies:
-      c12: 3.1.0
-      deepmerge-ts: 7.1.5
-      effect: 3.16.12
-      empathic: 2.0.0
-    transitivePeerDependencies:
-      - magicast
 
   '@prisma/config@6.8.2':
     dependencies:
       jiti: 2.4.2
 
-  '@prisma/debug@6.16.2': {}
+  '@prisma/config@7.0.0':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.18.4
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
 
   '@prisma/debug@6.8.2': {}
 
-  '@prisma/dmmf@6.16.2': {}
+  '@prisma/debug@7.0.0': {}
 
-  '@prisma/driver-adapter-utils@6.16.2':
+  '@prisma/dmmf@7.0.0': {}
+
+  '@prisma/driver-adapter-utils@7.0.0':
     dependencies:
-      '@prisma/debug': 6.16.2
+      '@prisma/debug': 7.0.0
 
-  '@prisma/engines-version@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43': {}
+  '@prisma/engines-version@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513': {}
 
   '@prisma/engines-version@6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e': {}
-
-  '@prisma/engines@6.16.2':
-    dependencies:
-      '@prisma/debug': 6.16.2
-      '@prisma/engines-version': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
-      '@prisma/fetch-engine': 6.16.2
-      '@prisma/get-platform': 6.16.2
 
   '@prisma/engines@6.8.2':
     dependencies:
@@ -1325,11 +1316,12 @@ snapshots:
       '@prisma/fetch-engine': 6.8.2
       '@prisma/get-platform': 6.8.2
 
-  '@prisma/fetch-engine@6.16.2':
+  '@prisma/engines@7.0.0':
     dependencies:
-      '@prisma/debug': 6.16.2
-      '@prisma/engines-version': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
-      '@prisma/get-platform': 6.16.2
+      '@prisma/debug': 7.0.0
+      '@prisma/engines-version': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
+      '@prisma/fetch-engine': 7.0.0
+      '@prisma/get-platform': 7.0.0
 
   '@prisma/fetch-engine@6.8.2':
     dependencies:
@@ -1337,36 +1329,42 @@ snapshots:
       '@prisma/engines-version': 6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e
       '@prisma/get-platform': 6.8.2
 
-  '@prisma/generator-helper@6.16.2':
+  '@prisma/fetch-engine@7.0.0':
     dependencies:
-      '@prisma/debug': 6.16.2
-      '@prisma/dmmf': 6.16.2
-      '@prisma/generator': 6.16.2
+      '@prisma/debug': 7.0.0
+      '@prisma/engines-version': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
+      '@prisma/get-platform': 7.0.0
 
-  '@prisma/generator@6.16.2': {}
-
-  '@prisma/get-platform@6.16.2':
+  '@prisma/generator-helper@7.0.0':
     dependencies:
-      '@prisma/debug': 6.16.2
+      '@prisma/debug': 7.0.0
+      '@prisma/dmmf': 7.0.0
+      '@prisma/generator': 7.0.0
+
+  '@prisma/generator@7.0.0': {}
 
   '@prisma/get-platform@6.8.2':
     dependencies:
       '@prisma/debug': 6.8.2
 
-  '@prisma/internals@6.16.2(typescript@5.8.3)':
+  '@prisma/get-platform@7.0.0':
     dependencies:
-      '@prisma/config': 6.16.2
-      '@prisma/debug': 6.16.2
-      '@prisma/dmmf': 6.16.2
-      '@prisma/driver-adapter-utils': 6.16.2
-      '@prisma/engines': 6.16.2
-      '@prisma/fetch-engine': 6.16.2
-      '@prisma/generator': 6.16.2
-      '@prisma/generator-helper': 6.16.2
-      '@prisma/get-platform': 6.16.2
-      '@prisma/prisma-schema-wasm': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
-      '@prisma/schema-engine-wasm': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
-      '@prisma/schema-files-loader': 6.16.2
+      '@prisma/debug': 7.0.0
+
+  '@prisma/internals@7.0.0(typescript@5.8.3)':
+    dependencies:
+      '@prisma/config': 7.0.0
+      '@prisma/debug': 7.0.0
+      '@prisma/dmmf': 7.0.0
+      '@prisma/driver-adapter-utils': 7.0.0
+      '@prisma/engines': 7.0.0
+      '@prisma/fetch-engine': 7.0.0
+      '@prisma/generator': 7.0.0
+      '@prisma/generator-helper': 7.0.0
+      '@prisma/get-platform': 7.0.0
+      '@prisma/prisma-schema-wasm': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
+      '@prisma/schema-engine-wasm': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
+      '@prisma/schema-files-loader': 7.0.0
       arg: 5.0.2
       prompts: 2.4.2
     optionalDependencies:
@@ -1374,18 +1372,18 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/prisma-schema-wasm@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43': {}
+  '@prisma/prisma-schema-wasm@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513': {}
 
-  '@prisma/schema-engine-wasm@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43': {}
+  '@prisma/schema-engine-wasm@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513': {}
 
-  '@prisma/schema-files-loader@6.16.2':
+  '@prisma/schema-files-loader@7.0.0':
     dependencies:
-      '@prisma/prisma-schema-wasm': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
+      '@prisma/prisma-schema-wasm': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
       fs-extra: 11.3.0
 
-  '@prisma/ts-builders@6.16.2(typescript@5.8.3)':
+  '@prisma/ts-builders@7.0.0(typescript@5.8.3)':
     dependencies:
-      '@prisma/internals': 6.16.2(typescript@5.8.3)
+      '@prisma/internals': 7.0.0(typescript@5.8.3)
     transitivePeerDependencies:
       - magicast
       - typescript
@@ -1475,7 +1473,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.41.0':
     optional: true
 
-  '@samchon/openapi@4.3.0': {}
+  '@samchon/openapi@5.1.0': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -1578,8 +1576,6 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  ci-info@4.2.0: {}
-
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
@@ -1630,8 +1626,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.5.0: {}
-
   deepmerge-ts@7.1.5: {}
 
   defaults@1.0.4:
@@ -1650,7 +1644,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  effect@3.16.12:
+  effect@3.18.4:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
@@ -1901,10 +1895,10 @@ snapshots:
 
   prettier@3.5.3: {}
 
-  prisma-markdown@3.0.1(@prisma/client@6.16.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3))(prisma@6.8.2(typescript@5.8.3)):
+  prisma-markdown@4.0.0(@prisma/client@7.0.0(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3))(prisma@6.8.2(typescript@5.8.3)):
     dependencies:
-      '@prisma/client': 6.16.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
-      '@prisma/generator-helper': 6.16.2
+      '@prisma/client': 7.0.0(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
+      '@prisma/generator-helper': 7.0.0
       prisma: 6.8.2(typescript@5.8.3)
 
   prisma@6.8.2(typescript@5.8.3):
@@ -2108,9 +2102,9 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typia@9.3.0(@samchon/openapi@4.3.0)(typescript@5.8.3):
+  typia@10.1.0(typescript@5.8.3):
     dependencies:
-      '@samchon/openapi': 4.3.0
+      '@samchon/openapi': 5.1.0
       '@standard-schema/spec': 1.0.0
       commander: 10.0.1
       comment-json: 4.2.5

--- a/src/EmbedPrisma.ts
+++ b/src/EmbedPrisma.ts
@@ -96,7 +96,6 @@ export class EmbedPrisma {
     const document: DMMF.Document = await getDMMF({ datamodel: schemas });
     const config: ConfigMetaFormat = await getConfig({
       datamodel: schemas,
-      ignoreEnvVarErrors: true,
     });
 
     // STORE SCHEMA FILES
@@ -113,7 +112,7 @@ export class EmbedPrisma {
       schemaPath: `${directory}/schemas`,
       outputDir: `${directory}/output`,
       runtimeSourcePath: require
-        .resolve("@prisma/client/runtime/library.js")
+        .resolve("@prisma/client/runtime/client.js")
         .split(path.sep)
         .slice(0, -1)
         .join(path.sep),

--- a/test/examples/bbs/main.prisma
+++ b/test/examples/bbs/main.prisma
@@ -1,11 +1,9 @@
 generator client {
-  provider   = "prisma-client-js"
-  engineType = "client"
+  provider   = "prisma-client"
 }
 
 datasource db {
   provider = "sqlite"
-  url      = "file:../db.sqlite"
 }
 
 generator markdown {

--- a/test/examples/shopping/main.prisma
+++ b/test/examples/shopping/main.prisma
@@ -1,12 +1,10 @@
 generator client {
-  provider        = "prisma-client-js"
-  engineType      = "client"
+  provider        = "prisma-client"
   previewFeatures = ["postgresqlExtensions", "views"]
 }
 
 datasource db {
   provider   = "postgresql"
-  url        = env("SHOPPING_POSTGRES_URL")
   extensions = [pg_trgm]
 }
 

--- a/test/package.json
+++ b/test/package.json
@@ -17,6 +17,6 @@
     "@nestia/e2e": "^6.0.3",
     "chalk": "4.1.2",
     "embed-prisma": "workspace:^",
-    "typia": "^9.3.0"
+    "typia": "^10.1.0"
   }
 }

--- a/test/src/features/test_compile_correct.ts
+++ b/test/src/features/test_compile_correct.ts
@@ -10,6 +10,7 @@ export const test_compiler_prisma_correct = async (): Promise<void> => {
     const result: IEmbedPrismaResult = await compiler.compile(
       await TestGlobal.readExampleSchemas(project),
     );
+    if (result.type !== "success") console.log(result);
     TestValidator.equals("result")(result.type)("success");
     typia.assertEquals(result.type);
   }


### PR DESCRIPTION
This pull request upgrades the project to use Prisma 7 and updates several related dependencies to their latest major versions. It also updates the Node.js version and setup actions in the release workflow to ensure compatibility with these new dependencies. These changes help keep the project current with upstream improvements and security fixes, and ensure smoother future maintenance.

**Dependency upgrades:**

* Upgraded all Prisma-related dependencies (`@prisma/client`, `@prisma/client-generator-js`, `@prisma/generator-helper`, `@prisma/internals`, and `prisma-markdown`) to version 7.x (and 4.x for `prisma-markdown`) in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R39) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R25) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL165-R255) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL882-R883) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1236-R1265)
* Updated other dependencies including `typia` to 10.x, `@samchon/openapi` to 5.x, and `effect` to 3.18.x in `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL64-R65) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL385-R389) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL598-R595) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1078-R1078)

**Release workflow updates:**

* Updated the GitHub Actions workflow to use Node.js 24.x and `actions/setup-node@v6` for publishing releases, ensuring compatibility with Prisma 7 requirements.
* Moved workflow permissions to the top-level and removed the explicit `NODE_AUTH_TOKEN` for npm publishing. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R3-R16) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28)

**Project configuration:**

* Added a new `.github/dependabot.yml` configuration to automate dependency updates for Prisma packages.

**Version bump:**

* Bumped the project version to `2.0.0` in `package.json` to reflect the breaking changes from major dependency upgrades.